### PR TITLE
Update README.md: add @master in uses: examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [action.yml](action.yml)
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: LizardByte/setup-python-action
+- uses: LizardByte/setup-python-action@main
   with:
     python-version: '3.10'
 - run: python my_script.py
@@ -24,7 +24,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: LizardByte/setup-python-action
+- uses: LizardByte/setup-python-action@main
   with:
     python-version: '2.7'
 - run: python my_script.py
@@ -34,7 +34,7 @@ steps:
 ```yaml
 steps:
 - uses: actions/checkout@v4
-- uses: LizardByte/setup-python-action
+- uses: LizardByte/setup-python-action@main
   with:
     python-version: 'pypy3.9'
 - run: python my_script.py


### PR DESCRIPTION
I was unable to use this action with the syntax in the README. This appears to fix it.

## Description
Replace `uses: LizardByte/setup-python-action` with `uses: LizardByte/setup-python-action@master` in all three examples

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [X] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
