### PR TITLE
ci: use commit hash for LizardByte actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,16 @@ jobs:
 
       - name: Run Action
         id: setup-release
-        uses: LizardByte/setup-release-action@v2023.10.22-c3791c6
+        # dependabot cannot pick up our tags, so use the commit hash
+        uses: LizardByte/setup-release-action@38bc9762d673470bd6f78613ae88b6b62c6e282b
         with:
           fail_on_events_api_error: true
           github_token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Create Release
         id: action
-        uses: LizardByte/create-release-action@v2023.10.22-57d76be
+        # dependabot cannot pick up our tags, so use the commit hash
+        uses: LizardByte/create-release-action@cd331e8752cdc0b66d75ad41ada0c16cae7cdf73
         with:
           allowUpdates: false
           artifacts: ''


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use commit hash for LizardByte actions, (hopefully) allowing dependabot to keep them up to date.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
