### PR TITLE
fix(macos): correct issue where pyenv will not install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,8 +44,18 @@ runs:
       shell: bash
       if: ${{ inputs.python-version == '2.7' && runner.os == 'macOS' }}
       run: |
+        # if macos version >= 13
+        if [[ $(sw_vers -productVersion | cut -d '.' -f1) -ge 13 ]]; then
+          echo "macOS version >= 13, relinking python@3.12 to avoid brew error"
+          brew unlink python@3.12
+          brew link --overwrite python@3.12
+        fi
+
+        # install pyenv
         brew install pyenv
         export PATH="$(pyenv root)/shims:$(pyenv root)/bin:$PATH"
+
+        # install python 2.7
         pyenv install 2.7.18
 
     - name: Setup Python Environment


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`pyenv` install on macOS 13 now depends on Python 3.12, which conflicts with the system installed python.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
