### PR TITLE
feat: support new runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,15 @@ jobs:
             python: 2.7
             architecture: x86
         os:
-          - macos-11
           - macos-12
           - macos-13
+          - macos-14
           - windows-2019
           - windows-2022
           - ubuntu-20.04
           - ubuntu-22.04
-        python: ["2.7", "3.8", "3.9", "3.10", "3.11"]
+          - ubuntu-24.04
+        python: ["2.7", "3.11"]
         architecture: ["x64"]
 
     runs-on: ${{ matrix.os }}

--- a/action.yml
+++ b/action.yml
@@ -35,36 +35,25 @@ runs:
 
         choco install python2 --version=2.7.18 -y --no-progress ${extra_flags}
 
-    - name: Linux Install
+    - name: Unix Install
       shell: bash
-      if: ${{ inputs.python-version == '2.7' && runner.os == 'Linux' }}
+      if: ${{ inputs.python-version == '2.7' && (runner.os == 'Linux' || runner.os == 'macOS') }}
       run: |
-        # get the version from /etc/os-release
-        version=$(grep -oP '(?<=VERSION_ID=")\d+' /etc/os-release)
-        echo "Ubuntu version: $version"
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          curl https://pyenv.run | bash
+          export PATH="$HOME/.pyenv/bin:$PATH"
+        elif [[ "${{ runner.os }}" == "macOS" ]]; then
+          # if macos version >= 13
+          if [[ $(sw_vers -productVersion | cut -d '.' -f1) -ge 13 ]]; then
+            echo "macOS version >= 13, relinking python@3.12 to avoid brew error"
+            brew unlink python@3.12
+            brew link --overwrite python@3.12
+          fi
 
-        sudo apt-get update
-
-        if [[ $version == 20 ]]; then
-          sudo apt-get install python2.7 -y
-        elif [[ $version == 22 ]]; then
-          sudo apt-get install python2 python-pip -y
+          # install pyenv
+          brew install pyenv
+          export PATH="$(pyenv root)/shims:$(pyenv root)/bin:$PATH"
         fi
-
-    - name: macOS Install
-      shell: bash
-      if: ${{ inputs.python-version == '2.7' && runner.os == 'macOS' }}
-      run: |
-        # if macos version >= 13
-        if [[ $(sw_vers -productVersion | cut -d '.' -f1) -ge 13 ]]; then
-          echo "macOS version >= 13, relinking python@3.12 to avoid brew error"
-          brew unlink python@3.12
-          brew link --overwrite python@3.12
-        fi
-
-        # install pyenv
-        brew install pyenv
-        export PATH="$(pyenv root)/shims:$(pyenv root)/bin:$PATH"
 
         # install python 2.7
         pyenv install 2.7.18
@@ -86,12 +75,15 @@ runs:
           venv_base_path="/c/tmp/python27/venv"
           venv_base_path_windows="C:\\tmp\\python27\\venv"
           venv_dir="Scripts"
-        elif [[ "${{ runner.os }}" == "Linux" ]]; then
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
-          venv_base_path="/tmp/python27/venv"
-          venv_dir="bin"
-        elif [[ "${{ runner.os }}" == "macOS" ]]; then
-          export PATH="$(pyenv root)/shims:$(pyenv root)/bin:$PATH"  # use this instead of GITHUB_PATH to be first
+        elif [[ "${{ runner.os }}" == "Linux" || "${{ runner.os }}" == "macOS" ]]; then
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            export PATH="$HOME/.pyenv/bin:$PATH"
+
+            # update alternatives
+            sudo update-alternatives --install /usr/bin/python python $(pyenv root)/shims/python 1
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            export PATH="$(pyenv root)/shims:$(pyenv root)/bin:$PATH"  # use this instead of GITHUB_PATH to be first
+          fi
           pyenv global 2.7.18
           # set python to use `$(pyenv root)/versions/2.7.18/bin`
           # export PATH="$(pyenv root)/versions/2.7.18/bin:$PATH"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Add support for macos-14
- Add support for ubuntu-24.04
- Drop testing of python3 versions < 3.11 (to consume less runners)
- Drop testing of macos-11 (deprecated... but it should still work)
- Use pyenv for Linux


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
