### PR TITLE
ci(matrix): drop windows-2019 and add windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             python: 2.7
             architecture: x86
-          - os: windows-2022
+          - os: windows-2025
             python: 2.7
             architecture: x86
         os:
           - macos-13
           - macos-14
-          - windows-2019
           - windows-2022
+          - windows-2025
           - ubuntu-22.04
           - ubuntu-24.04
         python:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`windows-2019` runner is deprecated and will be removed by June 30, 2025.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
